### PR TITLE
[WIP] Support Transpose in Scala DataFrame API

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -3936,14 +3936,16 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
           child = child
         )
 
+        val keyExpr = UnresolvedAttribute("key")
+        val valueExpr = UnresolvedAttribute("value")
+
         val aggExpression = First(
-          AttributeReference("value", valueType)(), ignoreNulls = true
-        ).toAggregateExpression(isDistinct = true)
+          valueExpr, ignoreNulls = true).toAggregateExpression(isDistinct = true)
 
         val pivot = Pivot(
-          groupByExprsOpt = Some(Seq(AttributeReference("key", StringType)())),
+          groupByExprsOpt = Some(Seq(keyExpr)),
           pivotColumn = firstColumnNamedExpr,
-          pivotValues = firstColumnValues,
+          pivotValues = Seq(Literal("dotNET"), Literal("Java")),
           aggregates = Seq(aggExpression),
           child = unpivot
         )

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -3923,7 +3923,7 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
     def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperatorsWithPruning(
       _.containsPattern(TRANSPOSE), ruleId) {
       // scalastyle:off println
-      case t @ Transpose(child, firstColumnValues, valueType) =>
+      case t @ Transpose(firstColumnValues, valueType, child) =>
         val firstColumn = child.output.head
         val firstColumnNamedExpr = firstColumn.asInstanceOf[NamedExpression]
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -3923,7 +3923,7 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
     def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperatorsWithPruning(
       _.containsPattern(TRANSPOSE), ruleId) {
       // scalastyle:off println
-      case t @ Transpose(firstColumnValues, valueType, child) =>
+      case t @ Transpose(firstColumnValues, child) =>
         val firstColumn = child.output.head
         val firstColumnNamedExpr = firstColumn.asInstanceOf[NamedExpression]
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -3926,13 +3926,27 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
       case t @ Transpose(columnsToTranspose, columnAlias, orderExpression, child) =>
 //      case t @ Transpose(columnsToTranspose, columnAlias, orderExpression, child)
 //        if t.expressions.forall(_.resolved) && child.resolved =>
+
+        // scalastyle:off println
         val pivotColumnName = "__pivot_column"
 
-        // Concatenate the values of columns in columnsToTranspose using an underscore
         val concatExpr = ConcatWs(Literal("_") +: columnsToTranspose)
         val aliasExpr = Alias(concatExpr, pivotColumnName)()
         val tempChild = Project(child.output :+ aliasExpr, child)
+
         val columnsToKeep = child.output.filterNot(columnsToTranspose.contains)
+
+        val pivotValues = columnsToTranspose.map(_.asInstanceOf[NamedExpression])
+
+
+        println("Unpivot ids: " + Some(Seq(AttributeReference(pivotColumnName, StringType)())))
+        println(
+          "Unpivot values: " + Some(
+            columnsToKeep.map(col => Seq(col.asInstanceOf[NamedExpression])))
+        )
+        println("Unpivot variableColumnName: " + columnAlias)
+        println("Unpivot valueColumnNames: " + Seq("value"))
+        println("Unpivot child: " + tempChild.schema.treeString)
 
         val unpivot = Unpivot(
           ids = Some(Seq(AttributeReference(pivotColumnName, StringType)())),
@@ -3942,18 +3956,25 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
           valueColumnNames = Seq("value"),
           child = tempChild
         )
+        println("Unpivot logical node: " + unpivot)
+        println("Unpivot schema: " + unpivot.schema.treeString)
+
+        val valueType = unpivot.schema.find(_.name == "value").map(_.dataType).getOrElse(DoubleType)
+        val firstAgg = Alias(
+          First(AttributeReference("value", valueType)(), ignoreNulls = true),
+          "temp_value"
+        )()
 
         val pivot = Pivot(
           groupByExprsOpt = Some(Seq(AttributeReference(columnAlias, StringType)())),
           pivotColumn = AttributeReference(pivotColumnName, StringType)(),
-          pivotValues = Nil,
-          aggregates = Seq(
-            Alias(First(AttributeReference("value", StringType)(), ignoreNulls = true), "value")()
-          ),
+          pivotValues = pivotValues.map(expr => Literal(expr.name)),
+          aggregates = Seq(firstAgg),
           child = unpivot
         )
 
         pivot
+      // scalastyle:on println
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -59,6 +59,7 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.types.DayTimeIntervalType.DAY
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.util.ArrayImplicits._
+
 /**
  * A trivial [[Analyzer]] with a dummy [[SessionCatalog]] and
  * [[EmptyTableFunctionRegistry]]. Used for testing when all relations are already filled

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -3918,6 +3918,42 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
         c.storeAnalyzedQuery()
     }
   }
+
+  object ResolveTranspose extends Rule[LogicalPlan] {
+    def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperatorsWithPruning(
+      _.containsPattern(TRANSPOSE), ruleId) {
+      case t @ Transpose(columnsToTranspose, columnAlias, orderExpression, child)
+        if t.expressions.forall(_.resolved) && child.resolved =>
+
+        val pivotColumnName = "__pivot_column"
+
+        // Concatenate the values of columns in columnsToTranspose using an underscore
+        val concatExpr = ConcatWs(Literal("_") +: columnsToTranspose)
+        val aliasExpr = Alias(concatExpr, pivotColumnName)()
+        val tempChild = Project(child.output :+ aliasExpr, child)
+        val columnsToKeep = child.output.filterNot(columnsToTranspose.contains)
+
+        val unpivot = Unpivot(
+          ids = Some(Seq(AttributeReference(pivotColumnName, StringType)())),
+          values = Some(columnsToKeep.map(col => Seq(col.asInstanceOf[NamedExpression]))),
+          aliases = None,
+          variableColumnName = columnAlias,
+          valueColumnNames = Seq("value"),
+          child = tempChild
+        )
+
+        val pivot = Pivot(
+          groupByExprsOpt = Some(Seq(AttributeReference(columnAlias, StringType)())),
+          pivotColumn = AttributeReference(pivotColumnName, StringType)(),
+          pivotValues = Nil,
+          aggregates = Seq(
+            Alias(First(AttributeReference("value", StringType)(), ignoreNulls = true), "value")()),
+          child = unpivot
+        )
+
+        pivot
+    }
+  }
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -3945,7 +3945,7 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
         val pivot = Pivot(
           groupByExprsOpt = Some(Seq(keyExpr)),
           pivotColumn = firstColumnNamedExpr,
-          pivotValues = Seq(Literal("dotNET"), Literal("Java")),
+          pivotValues = firstColumnValues,
           aggregates = Seq(aggExpression),
           child = unpivot
         )

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -3924,12 +3924,11 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
     def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperatorsWithPruning(
       _.containsPattern(TRANSPOSE), ruleId) {
       // scalastyle:off println
-      case t @ Transpose(firstColumnValues, child) =>
-        val firstColumn = child.output.head
-        val firstColumnNamedExpr = firstColumn.asInstanceOf[NamedExpression]
+      case t @ Transpose(indexColumn, indexColumnValues, child) =>
+        val indexColumnNamedExpr = indexColumn.asInstanceOf[NamedExpression]
 
         val unpivot = Unpivot(
-          ids = Some(Seq(firstColumnNamedExpr)),
+          ids = Some(Seq(indexColumnNamedExpr)),
           values = None,
           aliases = None,
           variableColumnName = "key",
@@ -3945,8 +3944,8 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
 
         val pivot = Pivot(
           groupByExprsOpt = Some(Seq(keyExpr)),
-          pivotColumn = firstColumnNamedExpr,
-          pivotValues = firstColumnValues,
+          pivotColumn = indexColumnNamedExpr,
+          pivotValues = indexColumnValues,
           aggregates = Seq(aggExpression),
           child = unpivot
         )

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -294,6 +294,7 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
       ResolveGroupingAnalytics ::
       ResolvePivot ::
       ResolveUnpivot ::
+      ResolveTranspose ::
       ResolveOrdinalInOrderByAndGroupBy ::
       ExtractGenerator ::
       ResolveGenerate ::
@@ -3922,9 +3923,9 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
   object ResolveTranspose extends Rule[LogicalPlan] {
     def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperatorsWithPruning(
       _.containsPattern(TRANSPOSE), ruleId) {
-      case t @ Transpose(columnsToTranspose, columnAlias, orderExpression, child)
-        if t.expressions.forall(_.resolved) && child.resolved =>
-
+      case t @ Transpose(columnsToTranspose, columnAlias, orderExpression, child) =>
+//      case t @ Transpose(columnsToTranspose, columnAlias, orderExpression, child)
+//        if t.expressions.forall(_.resolved) && child.resolved =>
         val pivotColumnName = "__pivot_column"
 
         // Concatenate the values of columns in columnsToTranspose using an underscore
@@ -3947,7 +3948,8 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
           pivotColumn = AttributeReference(pivotColumnName, StringType)(),
           pivotValues = Nil,
           aggregates = Seq(
-            Alias(First(AttributeReference("value", StringType)(), ignoreNulls = true), "value")()),
+            Alias(First(AttributeReference("value", StringType)(), ignoreNulls = true), "value")()
+          ),
           child = unpivot
         )
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -59,7 +59,6 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.types.DayTimeIntervalType.DAY
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.util.ArrayImplicits._
-
 /**
  * A trivial [[Analyzer]] with a dummy [[SessionCatalog]] and
  * [[EmptyTableFunctionRegistry]]. Used for testing when all relations are already filled
@@ -3923,58 +3922,35 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
   object ResolveTranspose extends Rule[LogicalPlan] {
     def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperatorsWithPruning(
       _.containsPattern(TRANSPOSE), ruleId) {
-      case t @ Transpose(columnsToTranspose, columnAlias, orderExpression, child) =>
-//      case t @ Transpose(columnsToTranspose, columnAlias, orderExpression, child)
-//        if t.expressions.forall(_.resolved) && child.resolved =>
-
-        // scalastyle:off println
-        val pivotColumnName = "__pivot_column"
-
-        val concatExpr = ConcatWs(Literal("_") +: columnsToTranspose)
-        val aliasExpr = Alias(concatExpr, pivotColumnName)()
-        val tempChild = Project(child.output :+ aliasExpr, child)
-
-        val columnsToKeep = child.output.filterNot(columnsToTranspose.contains)
-
-        val pivotValues = columnsToTranspose.map(_.asInstanceOf[NamedExpression])
-
-
-        println("Unpivot ids: " + Some(Seq(AttributeReference(pivotColumnName, StringType)())))
-        println(
-          "Unpivot values: " + Some(
-            columnsToKeep.map(col => Seq(col.asInstanceOf[NamedExpression])))
-        )
-        println("Unpivot variableColumnName: " + columnAlias)
-        println("Unpivot valueColumnNames: " + Seq("value"))
-        println("Unpivot child: " + tempChild.schema.treeString)
+      // scalastyle:off println
+      case t @ Transpose(child) =>
+        val firstColumn = child.output.head
+        val firstColumnNamedExpr = firstColumn.asInstanceOf[NamedExpression]
 
         val unpivot = Unpivot(
-          ids = Some(Seq(AttributeReference(pivotColumnName, StringType)())),
-          values = Some(columnsToKeep.map(col => Seq(col.asInstanceOf[NamedExpression]))),
+          ids = Some(Seq(firstColumnNamedExpr)),
+          values = None,
           aliases = None,
-          variableColumnName = columnAlias,
+          variableColumnName = "key",
           valueColumnNames = Seq("value"),
-          child = tempChild
+          child = child
         )
-        println("Unpivot logical node: " + unpivot)
-        println("Unpivot schema: " + unpivot.schema.treeString)
 
-        val valueType = unpivot.schema.find(_.name == "value").map(_.dataType).getOrElse(DoubleType)
-        val firstAgg = Alias(
-          First(AttributeReference("value", valueType)(), ignoreNulls = true),
-          "temp_value"
-        )()
+        val valueColumnDataType = IntegerType  // to fix
+        val pivotValues: Seq[Expression] = Seq(Literal("dotNET"), Literal("Java")) // to fix
+        val aggFunction = First(
+          AttributeReference("value", valueColumnDataType)(), ignoreNulls = true)
+        val aggExpression = aggFunction.toAggregateExpression(isDistinct = true, None) // to fix
 
         val pivot = Pivot(
-          groupByExprsOpt = Some(Seq(AttributeReference(columnAlias, StringType)())),
-          pivotColumn = AttributeReference(pivotColumnName, StringType)(),
-          pivotValues = pivotValues.map(expr => Literal(expr.name)),
-          aggregates = Seq(firstAgg),
+          groupByExprsOpt = Some(Seq(AttributeReference("key", StringType)())),
+          pivotColumn = firstColumnNamedExpr,
+          pivotValues = pivotValues,
+          aggregates = Seq(aggExpression),
           child = unpivot
         )
 
         pivot
-      // scalastyle:on println
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -3923,7 +3923,7 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
     def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperatorsWithPruning(
       _.containsPattern(TRANSPOSE), ruleId) {
       // scalastyle:off println
-      case t @ Transpose(child) =>
+      case t @ Transpose(child, firstColumnValues) =>
         val firstColumn = child.output.head
         val firstColumnNamedExpr = firstColumn.asInstanceOf[NamedExpression]
 
@@ -3937,15 +3937,14 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
         )
 
         val valueColumnDataType = IntegerType  // to fix
-        val pivotValues: Seq[Expression] = Seq(Literal("dotNET"), Literal("Java")) // to fix
-        val aggFunction = First(
-          AttributeReference("value", valueColumnDataType)(), ignoreNulls = true)
-        val aggExpression = aggFunction.toAggregateExpression(isDistinct = true, None) // to fix
+        val aggExpression = First(
+          AttributeReference("value", valueColumnDataType)(), ignoreNulls = true
+        ).toAggregateExpression(isDistinct = true)
 
         val pivot = Pivot(
           groupByExprsOpt = Some(Seq(AttributeReference("key", StringType)())),
           pivotColumn = firstColumnNamedExpr,
-          pivotValues = pivotValues,
+          pivotValues = firstColumnValues,
           aggregates = Seq(aggExpression),
           child = unpivot
         )

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -3923,7 +3923,7 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
     def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperatorsWithPruning(
       _.containsPattern(TRANSPOSE), ruleId) {
       // scalastyle:off println
-      case t @ Transpose(child, firstColumnValues) =>
+      case t @ Transpose(child, firstColumnValues, valueType) =>
         val firstColumn = child.output.head
         val firstColumnNamedExpr = firstColumn.asInstanceOf[NamedExpression]
 
@@ -3936,9 +3936,8 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
           child = child
         )
 
-        val valueColumnDataType = IntegerType  // to fix
         val aggExpression = First(
-          AttributeReference("value", valueColumnDataType)(), ignoreNulls = true
+          AttributeReference("value", valueType)(), ignoreNulls = true
         ).toAggregateExpression(isDistinct = true)
 
         val pivot = Pivot(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -1472,7 +1472,6 @@ case class Pivot(
 
 case class Transpose (
     firstColumnValues: Seq[Expression],
-    valueType: DataType,
     child: LogicalPlan
 ) extends UnresolvedUnaryNode {
   final override val nodePatterns: Seq[TreePattern] = Seq(TRANSPOSE)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -1471,9 +1471,9 @@ case class Pivot(
 }
 
 case class Transpose (
-    child: LogicalPlan,
     firstColumnValues: Seq[Expression],
-    valueType: DataType
+    valueType: DataType,
+    child: LogicalPlan
 ) extends UnresolvedUnaryNode {
   final override val nodePatterns: Seq[TreePattern] = Seq(TRANSPOSE)
   override def withNewChildInternal(newChild: LogicalPlan): Transpose = copy(child = newChild)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -1470,6 +1470,15 @@ case class Pivot(
   override protected def withNewChildInternal(newChild: LogicalPlan): Pivot = copy(child = newChild)
 }
 
+case class Transpose (
+     columnsToTranspose: Seq[Expression],
+     columnAlias: Expression,
+     orderExpression: Expression,
+     child: LogicalPlan) extends UnresolvedUnaryNode {
+  final override val nodePatterns: Seq[TreePattern] = Seq(TRANSPOSE)
+  override def withNewChildInternal(newChild: LogicalPlan): Transpose = copy(child = newChild)
+}
+
 
 /**
  * A constructor for creating an Unpivot, which will later be converted to an [[Expand]]

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -1472,7 +1472,7 @@ case class Pivot(
 
 case class Transpose (
      columnsToTranspose: Seq[Expression],
-     columnAlias: Expression,
+     columnAlias: String,
      orderExpression: Expression,
      child: LogicalPlan) extends UnresolvedUnaryNode {
   final override val nodePatterns: Seq[TreePattern] = Seq(TRANSPOSE)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -1471,7 +1471,8 @@ case class Pivot(
 }
 
 case class Transpose (
-    firstColumnValues: Seq[Expression],
+    indexColumn: Expression,
+    indexColumnValues: Seq[Expression],
     child: LogicalPlan
 ) extends UnresolvedUnaryNode {
   final override val nodePatterns: Seq[TreePattern] = Seq(TRANSPOSE)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -1470,11 +1470,7 @@ case class Pivot(
   override protected def withNewChildInternal(newChild: LogicalPlan): Pivot = copy(child = newChild)
 }
 
-case class Transpose (
-     columnsToTranspose: Seq[Expression],
-     columnAlias: String,
-     orderExpression: Expression,
-     child: LogicalPlan) extends UnresolvedUnaryNode {
+case class Transpose (child: LogicalPlan) extends UnresolvedUnaryNode {
   final override val nodePatterns: Seq[TreePattern] = Seq(TRANSPOSE)
   override def withNewChildInternal(newChild: LogicalPlan): Transpose = copy(child = newChild)
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -1470,7 +1470,10 @@ case class Pivot(
   override protected def withNewChildInternal(newChild: LogicalPlan): Pivot = copy(child = newChild)
 }
 
-case class Transpose (child: LogicalPlan) extends UnresolvedUnaryNode {
+case class Transpose (
+    child: LogicalPlan,
+    firstColumnValues: Seq[Expression]
+) extends UnresolvedUnaryNode {
   final override val nodePatterns: Seq[TreePattern] = Seq(TRANSPOSE)
   override def withNewChildInternal(newChild: LogicalPlan): Transpose = copy(child = newChild)
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -1472,7 +1472,8 @@ case class Pivot(
 
 case class Transpose (
     child: LogicalPlan,
-    firstColumnValues: Seq[Expression]
+    firstColumnValues: Seq[Expression],
+    valueType: DataType
 ) extends UnresolvedUnaryNode {
   final override val nodePatterns: Seq[TreePattern] = Seq(TRANSPOSE)
   override def withNewChildInternal(newChild: LogicalPlan): Transpose = copy(child = newChild)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
@@ -70,6 +70,7 @@ object RuleIdCollection {
       "org.apache.spark.sql.catalyst.analysis.Analyzer$ResolveSubqueryColumnAliases" ::
       "org.apache.spark.sql.catalyst.analysis.Analyzer$ResolveTables" ::
       "org.apache.spark.sql.catalyst.analysis.Analyzer$ResolveTempViews" ::
+      "org.apache.spark.sql.catalyst.analysis.Analyzer$ResolveTranspose" ::
       "org.apache.spark.sql.catalyst.analysis.Analyzer$ResolveUnpivot" ::
       "org.apache.spark.sql.catalyst.analysis.Analyzer$ResolveUpCast" ::
       "org.apache.spark.sql.catalyst.analysis.Analyzer$ResolveUserSpecifiedColumns" ::

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
@@ -92,6 +92,7 @@ object TreePattern extends Enumeration  {
   val SUM: Value = Value
   val TIME_WINDOW: Value = Value
   val TIME_ZONE_AWARE_EXPRESSION: Value = Value
+  val TRANSPOSE: Value = Value
   val TRUE_OR_FALSE_LITERAL: Value = Value
   val VARIANT_GET: Value = Value
   val WINDOW_EXPRESSION: Value = Value

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2174,12 +2174,9 @@ class Dataset[T] private[sql](
     unpivot(ids.toArray, variableColumnName, valueColumnName)
 
 
-  def transpose(
-      firstColumnValues: Seq[Column],
-      valueType: DataType): DataFrame = withPlan {
+  def transpose(firstColumnValues: Seq[Column]): DataFrame = withPlan {
     Transpose(
       firstColumnValues.map(_.expr),
-      valueType,
       logicalPlan
     )
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2183,10 +2183,14 @@ class Dataset[T] private[sql](
    */
   def transpose(): DataFrame = withPlan {
     val firstColumnValues = collectFirstColumnValues()
-    Transpose(
-      firstColumnValues.map(v => Literal(v.toString)),
-      logicalPlan
-    )
+    if (this.isEmpty) {
+      this.logicalPlan
+    } else {
+      Transpose(
+        firstColumnValues.map(v => Literal(v.toString)),
+        logicalPlan
+      )
+    }
   }
 
   private[sql] def collectFirstColumnValues(): Seq[Any] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2180,7 +2180,7 @@ class Dataset[T] private[sql](
     Transpose(
       firstColumnValues.map(_.expr),
       valueType,
-      logicalPlan,
+      logicalPlan
     )
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2174,9 +2174,9 @@ class Dataset[T] private[sql](
     unpivot(ids.toArray, variableColumnName, valueColumnName)
 
 
-  def transpose(firstColumnValues: Seq[Column]): DataFrame = withPlan {
+  def transpose(firstColumnValues: Seq[ColumnName]): DataFrame = withPlan {
     Transpose(
-      firstColumnValues.map(_.expr),
+      firstColumnValues.map(col => Literal(col.toString())),
       logicalPlan
     )
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2176,7 +2176,7 @@ class Dataset[T] private[sql](
   /**
    * Transpose a DataFrame, switching rows to columns.
    * This function transforms the DataFrame such that the distinct values in the first column become
-   * the new columns of the DataFrame.
+   * the new columns of the DataFrame. Note that values transposed must share the least common type.
    *
    * @group untypedrel
    * @since 4.0.0

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2194,15 +2194,13 @@ class Dataset[T] private[sql](
   }
 
   private[sql] def collectFirstColumnValues(): Seq[Any] = {
-
-    // This is to prevent unintended OOM errors when the number of distinct values is large
+    // TODO: configurable maxValues
     val maxValues = 5000
-    // Get the distinct values of the column and sort them so its consistent
     val firstColumn = col(this.columns.head)
     val values = this.select(firstColumn)
       .distinct()
       .limit(maxValues + 1)
-      .sort(firstColumn) // ensure that the output columns are in a consistent logical order
+      .sort(firstColumn)
       .collect()
       .map(_.get(0))
       .toImmutableArraySeq

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2175,32 +2175,36 @@ class Dataset[T] private[sql](
 
   /**
    * Transpose a DataFrame, switching rows to columns.
-   * This function transforms the DataFrame such that the distinct values in the first column become
-   * the new columns of the DataFrame. Note that values transposed must share the least common type.
+   * This function transforms the DataFrame such that the distinct values in the specified index
+   * column become the new columns of the DataFrame. If no index column is provided, the first
+   * column is used as the default. Note that values transposed must share the least common type.
    *
+   * @param indexColumn The column to use as the index for transposing. If not provided, the first
+   * column is used.
    * @group untypedrel
    * @since 4.0.0
    */
-  def transpose(): DataFrame = withPlan {
-    val firstColumnValues = collectFirstColumnValues()
+  def transpose(indexColumn: Option[Column] = None): DataFrame = withPlan {
+    val actualIndexColumn = indexColumn.getOrElse(col(this.columns.head))
+    val indexColumnValues = collectIndexColumnValues(actualIndexColumn)
     if (this.isEmpty) {
       this.logicalPlan
     } else {
       Transpose(
-        firstColumnValues.map(v => Literal(v.toString)),
+        actualIndexColumn.named,
+        indexColumnValues.map(v => Literal(v.toString)),
         logicalPlan
       )
     }
   }
 
-  private[sql] def collectFirstColumnValues(): Seq[Any] = {
+  private[sql] def collectIndexColumnValues(indexColumn: Column): Seq[Any] = {
     // TODO: configurable maxValues
     val maxValues = 5000
-    val firstColumn = col(this.columns.head)
-    val values = this.select(firstColumn)
+    val values = this.select(indexColumn)
       .distinct()
       .limit(maxValues + 1)
-      .sort(firstColumn)
+      .sort(indexColumn)
       .collect()
       .map(_.get(0))
       .toImmutableArraySeq

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2173,6 +2173,17 @@ class Dataset[T] private[sql](
       valueColumnName: String): DataFrame =
     unpivot(ids.toArray, variableColumnName, valueColumnName)
 
+
+  def transpose(
+      firstColumnValues: Seq[Column],
+      valueType: DataType): DataFrame = withPlan {
+    Transpose(
+      firstColumnValues.map(_.expr),
+      valueType,
+      logicalPlan,
+    )
+  }
+
   /**
    * Unpivot a DataFrame from wide format to long format, optionally leaving identifier columns set.
    * This is the reverse to `groupBy(...).pivot(...).agg(...)`, except for the aggregation,

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2179,8 +2179,8 @@ class Dataset[T] private[sql](
    * column become the new columns of the DataFrame. If no index column is provided, the first
    * column is used as the default. Note that values transposed must share the least common type.
    *
-   * @param indexColumn The column to use as the index for transposing. If not provided, the first
-   * column is used.
+   * @param indexColumn The single column to use as the index for transposing. If not provided,
+   * the first column is used.
    * @group untypedrel
    * @since 4.0.0
    */

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2174,7 +2174,7 @@ class Dataset[T] private[sql](
     unpivot(ids.toArray, variableColumnName, valueColumnName)
 
 
-  def transpose(firstColumnValues: Seq[ColumnName]): DataFrame = withPlan {
+  def transpose(firstColumnValues: Seq[Column]): DataFrame = withPlan {
     Transpose(
       firstColumnValues.map(col => Literal(col.toString())),
       logicalPlan

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2175,20 +2175,35 @@ class Dataset[T] private[sql](
 
   /**
    * Transpose a DataFrame, switching rows to columns.
-   * This function transforms the DataFrame such that the given values in the first column become
+   * This function transforms the DataFrame such that the distinct values in the first column become
    * the new columns of the DataFrame.
-   *
-   * @param firstColumnValues The distinct values of the first column which will become the new
-   *                          column headers in the transposed DataFrame.
    *
    * @group untypedrel
    * @since 4.0.0
    */
-  def transpose(firstColumnValues: Seq[String]): DataFrame = withPlan {
+  def transpose(): DataFrame = withPlan {
+    val firstColumnValues = collectFirstColumnValues()
     Transpose(
-      firstColumnValues.map(v => Literal(v)),
+      firstColumnValues.map(v => Literal(v.toString)),
       logicalPlan
     )
+  }
+
+  private[sql] def collectFirstColumnValues(): Seq[Any] = {
+
+    // This is to prevent unintended OOM errors when the number of distinct values is large
+    val maxValues = 5000
+    // Get the distinct values of the column and sort them so its consistent
+    val firstColumn = col(this.columns.head)
+    val values = this.select(firstColumn)
+      .distinct()
+      .limit(maxValues + 1)
+      .sort(firstColumn) // ensure that the output columns are in a consistent logical order
+      .collect()
+      .map(_.get(0))
+      .toImmutableArraySeq
+
+    values
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2179,8 +2179,11 @@ class Dataset[T] private[sql](
    * column become the new columns of the DataFrame. If no index column is provided, the first
    * column is used as the default. Note that values transposed must share the least common type.
    *
-   * @param indexColumn The single column to use as the index for transposing. If not provided,
-   * the first column is used.
+   * @param indexColumn The single column that will be treated as the index for the transpose
+   * operation.This column will be used to pivot the data, transforming the DataFrame such that
+   * the values of the indexCol become the new columns in the transposed DataFrame. If not
+   * provided, the first column is used.
+   *
    * @group untypedrel
    * @since 4.0.0
    */

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -2173,10 +2173,20 @@ class Dataset[T] private[sql](
       valueColumnName: String): DataFrame =
     unpivot(ids.toArray, variableColumnName, valueColumnName)
 
-
-  def transpose(firstColumnValues: Seq[Column]): DataFrame = withPlan {
+  /**
+   * Transpose a DataFrame, switching rows to columns.
+   * This function transforms the DataFrame such that the given values in the first column become
+   * the new columns of the DataFrame.
+   *
+   * @param firstColumnValues The distinct values of the first column which will become the new
+   *                          column headers in the transposed DataFrame.
+   *
+   * @group untypedrel
+   * @since 4.0.0
+   */
+  def transpose(firstColumnValues: Seq[String]): DataFrame = withPlan {
     Transpose(
-      firstColumnValues.map(col => Literal(col.toString())),
+      firstColumnValues.map(v => Literal(v)),
       logicalPlan
     )
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTransposeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTransposeSuite.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.spark.sql.catalyst.analysis.{Analyzer, FunctionRegistry}
+import org.apache.spark.sql.catalyst.catalog.{InMemoryCatalog, SessionCatalog}
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.test.SharedSparkSession
+
+class DataFrameTransposeSuite extends QueryTest with SharedSparkSession {
+
+  test("logical plan transformation for transpose") {
+    val logicalPlan = courseSales.queryExecution.logical
+
+    // Manually construct Transpose logical plan
+    val transposePlan = Transpose(
+      columnsToTranspose = Seq(col("year").expr, col("sales").expr),
+      columnAlias = "variable",
+      orderExpression = Literal(1),
+      child = logicalPlan
+    )
+
+//    println(s"Logical plan before analysis:\n$transposePlan")
+
+    // Apply the ResolveTranspose rule
+    val testAnalyzer = new Analyzer(
+      new SessionCatalog(new InMemoryCatalog, FunctionRegistry.builtin))
+    val analyzedPlan = testAnalyzer.execute(transposePlan)
+
+//    println(s"Logical plan after analysis:\n$analyzedPlan")
+
+    // Verify the transformed plan
+    assert(analyzedPlan.isInstanceOf[Pivot])
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTransposeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTransposeSuite.scala
@@ -57,4 +57,11 @@ class DataFrameTransposeSuite extends QueryTest with SharedSparkSession {
       )
     )
   }
+
+  test("transpose frame with index column specified") {
+    checkAnswer(
+      salary.transpose(Some($"salary")),
+      Row("personId", 1, 0) :: Nil
+    )
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTransposeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTransposeSuite.scala
@@ -31,7 +31,7 @@ class DataFrameTransposeSuite extends QueryTest with SharedSparkSession {
 
     // Manually construct Transpose logical plan
     val transposePlan = Transpose(
-      columnsToTranspose = Seq(col("year").expr, col("sales").expr),
+      columnsToTranspose = Seq(col("course").expr),
       columnAlias = "variable",
       orderExpression = Literal(1),
       child = logicalPlan

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTransposeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTransposeSuite.scala
@@ -22,7 +22,6 @@ import org.apache.spark.sql.catalyst.catalog.{InMemoryCatalog, SessionCatalog}
 import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql.types.IntegerType
 
 class DataFrameTransposeSuite extends QueryTest with SharedSparkSession {
   import testImplicits._
@@ -31,8 +30,7 @@ class DataFrameTransposeSuite extends QueryTest with SharedSparkSession {
   test("logical plan transformation for transpose") {
     val transposePlan = Transpose(
       firstColumnValues = Seq(Literal("dotNET"), Literal("Java")),
-      valueType = IntegerType,
-      child = courseSales.queryExecution.logical
+      child = courseSalesDedup.queryExecution.logical
     )
 
     println(s"Logical plan before analysis:\n$transposePlan")
@@ -45,8 +43,8 @@ class DataFrameTransposeSuite extends QueryTest with SharedSparkSession {
   }
 
   test("transpose scala API") {
-    println(s"df: \n${courseSales.show()}")
-    val transposed = courseSales.transpose(Seq($"dotNET", $"Java"), IntegerType)
+    println(s"df: \n${courseSalesDedup.show()}")
+    val transposed = courseSalesDedup.transpose(Seq($"dotNET", $"Java"))
     println(s"transposed df: \n${transposed.show()}")
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTransposeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTransposeSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql
 
 import org.apache.spark.sql.catalyst.analysis.{Analyzer, FunctionRegistry}
 import org.apache.spark.sql.catalyst.catalog.{InMemoryCatalog, SessionCatalog}
+import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.test.SharedSparkSession
 
@@ -28,8 +29,10 @@ class DataFrameTransposeSuite extends QueryTest with SharedSparkSession {
     // scalastyle:off println
 
     val logicalPlan = courseSales.queryExecution.logical
+    val firstColumnValues = Seq(Literal("dotNET"), Literal("Java")) // to fix
     val transposePlan = Transpose(
-      child = logicalPlan
+      child = logicalPlan,
+      firstColumnValues = firstColumnValues
     )
 
     println(s"Logical plan before analysis:\n$transposePlan")

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTransposeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTransposeSuite.scala
@@ -24,8 +24,6 @@ import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.test.SharedSparkSession
 
 class DataFrameTransposeSuite extends QueryTest with SharedSparkSession {
-  import testImplicits._
-
   // scalastyle:off println
   test("logical plan transformation for transpose") {
     val transposePlan = Transpose(
@@ -44,7 +42,7 @@ class DataFrameTransposeSuite extends QueryTest with SharedSparkSession {
 
   test("transpose scala API") {
     println(s"df: \n${courseSalesDedup.show()}")
-    val transposed = courseSalesDedup.transpose(Seq($"dotNET", $"Java"))
+    val transposed = courseSalesDedup.transpose(Seq("dotNET", "Java"))
     println(s"transposed df: \n${transposed.show()}")
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTransposeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTransposeSuite.scala
@@ -19,36 +19,25 @@ package org.apache.spark.sql
 
 import org.apache.spark.sql.catalyst.analysis.{Analyzer, FunctionRegistry}
 import org.apache.spark.sql.catalyst.catalog.{InMemoryCatalog, SessionCatalog}
-import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans.logical._
-import org.apache.spark.sql.functions._
 import org.apache.spark.sql.test.SharedSparkSession
 
 class DataFrameTransposeSuite extends QueryTest with SharedSparkSession {
 
   test("logical plan transformation for transpose") {
-    val logicalPlan = courseSales.queryExecution.logical
+    // scalastyle:off println
 
-    // Manually construct Transpose logical plan
+    val logicalPlan = courseSales.queryExecution.logical
     val transposePlan = Transpose(
-      columnsToTranspose = Seq(col("course").expr),
-      columnAlias = "variable",
-      orderExpression = Literal(1),
       child = logicalPlan
     )
 
-    // scalastyle:off println
     println(s"Logical plan before analysis:\n$transposePlan")
 
-    // Apply the ResolveTranspose rule
     val testAnalyzer = new Analyzer(
       new SessionCatalog(new InMemoryCatalog, FunctionRegistry.builtin))
     val analyzedPlan = testAnalyzer.execute(transposePlan)
 
     println(s"Logical plan after analysis:\n$analyzedPlan")
-    // scalastyle:on println
-
-    // Verify the transformed plan
-    assert(analyzedPlan.isInstanceOf[Pivot])
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTransposeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTransposeSuite.scala
@@ -25,10 +25,10 @@ import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.IntegerType
 
 class DataFrameTransposeSuite extends QueryTest with SharedSparkSession {
+  import testImplicits._
 
+  // scalastyle:off println
   test("logical plan transformation for transpose") {
-    // scalastyle:off println
-
     val transposePlan = Transpose(
       firstColumnValues = Seq(Literal("dotNET"), Literal("Java")),
       valueType = IntegerType,
@@ -42,5 +42,11 @@ class DataFrameTransposeSuite extends QueryTest with SharedSparkSession {
     val analyzedPlan = testAnalyzer.execute(transposePlan)
 
     println(s"Logical plan after analysis:\n$analyzedPlan")
+  }
+
+  test("transpose scala API") {
+    println(s"df: \n${courseSales.show()}")
+    val transposed = courseSales.transpose(Seq($"dotNET", $"Java"), IntegerType)
+    println(s"transposed df: \n${transposed.show()}")
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTransposeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTransposeSuite.scala
@@ -29,11 +29,10 @@ class DataFrameTransposeSuite extends QueryTest with SharedSparkSession {
   test("logical plan transformation for transpose") {
     // scalastyle:off println
 
-    val logicalPlan = courseSales.queryExecution.logical
     val transposePlan = Transpose(
-      child = logicalPlan,
       firstColumnValues = Seq(Literal("dotNET"), Literal("Java")),
-      valueType = IntegerType
+      valueType = IntegerType,
+      child = courseSales.queryExecution.logical
     )
 
     println(s"Logical plan before analysis:\n$transposePlan")

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTransposeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTransposeSuite.scala
@@ -37,14 +37,16 @@ class DataFrameTransposeSuite extends QueryTest with SharedSparkSession {
       child = logicalPlan
     )
 
-//    println(s"Logical plan before analysis:\n$transposePlan")
+    // scalastyle:off println
+    println(s"Logical plan before analysis:\n$transposePlan")
 
     // Apply the ResolveTranspose rule
     val testAnalyzer = new Analyzer(
       new SessionCatalog(new InMemoryCatalog, FunctionRegistry.builtin))
     val analyzedPlan = testAnalyzer.execute(transposePlan)
 
-//    println(s"Logical plan after analysis:\n$analyzedPlan")
+    println(s"Logical plan after analysis:\n$analyzedPlan")
+    // scalastyle:on println
 
     // Verify the transformed plan
     assert(analyzedPlan.isInstanceOf[Pivot])

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTransposeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTransposeSuite.scala
@@ -44,4 +44,17 @@ class DataFrameTransposeSuite extends QueryTest with SharedSparkSession {
       Row("id", 1) :: Nil
     )
   }
+
+  test("transpose frame with columns of mismatch types") {
+    // TODO: designated error class for Transpose
+    checkError(
+      exception = intercept[AnalysisException] {
+        person.transpose()
+      },
+      errorClass = "UNPIVOT_VALUE_DATA_TYPE_MISMATCH",
+      parameters = Map(
+        "types" -> """"INT" (`age`), "STRING" (`name`)"""
+      )
+    )
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTransposeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTransposeSuite.scala
@@ -20,15 +20,28 @@ package org.apache.spark.sql
 import org.apache.spark.sql.test.SharedSparkSession
 
 class DataFrameTransposeSuite extends QueryTest with SharedSparkSession {
+  import testImplicits._
+
   // scalastyle:off println
   test("transpose") {
-    val expected = Row("salary", 2000.0, 1000.0) :: Nil
-    val transposed = salary.transpose()
-//    checkAnswer(
-//      transposed,
-//      expected
-//    )
-    println(s"df: \n${salary.show()}")
-    println(s"df: \n${transposed.show()}")
+    checkAnswer(
+      salary.transpose(),
+      Row("salary", 2000.0, 1000.0) :: Nil
+    )
+  }
+
+  test("transpose empty frame") {
+    checkAnswer(
+      emptyTestData.transpose(),
+      emptyTestData
+    )
+  }
+
+  test("transpose frame with repeated first column values") {
+    val repeatedDf = Seq(("test", 1), ("test", 2)).toDF("s", "id")
+    checkAnswer(
+      repeatedDf.transpose(),
+      Row("id", 1) :: Nil
+    )
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTransposeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTransposeSuite.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.catalyst.catalog.{InMemoryCatalog, SessionCatalog}
 import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.types.IntegerType
 
 class DataFrameTransposeSuite extends QueryTest with SharedSparkSession {
 
@@ -29,10 +30,10 @@ class DataFrameTransposeSuite extends QueryTest with SharedSparkSession {
     // scalastyle:off println
 
     val logicalPlan = courseSales.queryExecution.logical
-    val firstColumnValues = Seq(Literal("dotNET"), Literal("Java")) // to fix
     val transposePlan = Transpose(
       child = logicalPlan,
-      firstColumnValues = firstColumnValues
+      firstColumnValues = Seq(Literal("dotNET"), Literal("Java")),
+      valueType = IntegerType
     )
 
     println(s"Logical plan before analysis:\n$transposePlan")

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTransposeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameTransposeSuite.scala
@@ -17,32 +17,18 @@
 
 package org.apache.spark.sql
 
-import org.apache.spark.sql.catalyst.analysis.{Analyzer, FunctionRegistry}
-import org.apache.spark.sql.catalyst.catalog.{InMemoryCatalog, SessionCatalog}
-import org.apache.spark.sql.catalyst.expressions.Literal
-import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.test.SharedSparkSession
 
 class DataFrameTransposeSuite extends QueryTest with SharedSparkSession {
   // scalastyle:off println
-  test("logical plan transformation for transpose") {
-    val transposePlan = Transpose(
-      firstColumnValues = Seq(Literal("dotNET"), Literal("Java")),
-      child = courseSalesDedup.queryExecution.logical
-    )
-
-    println(s"Logical plan before analysis:\n$transposePlan")
-
-    val testAnalyzer = new Analyzer(
-      new SessionCatalog(new InMemoryCatalog, FunctionRegistry.builtin))
-    val analyzedPlan = testAnalyzer.execute(transposePlan)
-
-    println(s"Logical plan after analysis:\n$analyzedPlan")
-  }
-
-  test("transpose scala API") {
-    println(s"df: \n${courseSalesDedup.show()}")
-    val transposed = courseSalesDedup.transpose(Seq("dotNET", "Java"))
-    println(s"transposed df: \n${transposed.show()}")
+  test("transpose") {
+    val expected = Row("salary", 2000.0, 1000.0) :: Nil
+    val transposed = salary.transpose()
+//    checkAnswer(
+//      transposed,
+//      expected
+//    )
+    println(s"df: \n${salary.show()}")
+    println(s"df: \n${transposed.show()}")
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestData.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestData.scala
@@ -280,14 +280,6 @@ private[sql] trait SQLTestData { self =>
     df
   }
 
-  protected lazy val courseSalesDedup: DataFrame = {
-    val df = spark.sparkContext.parallelize(
-        CourseSales("dotNET", 2013, 48000) ::
-        CourseSales("Java", 2013, 30000) :: Nil).toDF()
-    df.createOrReplaceTempView("courseSalesDedup")
-    df
-  }
-
   protected lazy val trainingSales: DataFrame = {
     val df = spark.sparkContext.parallelize(
       TrainingSales("Experts", CourseSales("dotNET", 2012, 10000)) ::

--- a/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestData.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/test/SQLTestData.scala
@@ -280,6 +280,14 @@ private[sql] trait SQLTestData { self =>
     df
   }
 
+  protected lazy val courseSalesDedup: DataFrame = {
+    val df = spark.sparkContext.parallelize(
+        CourseSales("dotNET", 2013, 48000) ::
+        CourseSales("Java", 2013, 30000) :: Nil).toDF()
+    df.createOrReplaceTempView("courseSalesDedup")
+    df
+  }
+
   protected lazy val trainingSales: DataFrame = {
     val df = spark.sparkContext.parallelize(
       TrainingSales("Experts", CourseSales("dotNET", 2012, 10000)) ::


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support
- logical operator "Transpose"
- "ResolveTranspose" analyzer rule
- Scala DataFrame API

Add tests.

#### How transpose works

```scala
scala> val df = Seq(("test1", 1), ("test2", 2)).toDF("s", "id")
val df: org.apache.spark.sql.DataFrame = [s: string, id: int]

scala> df.show()
+-----+---+
|    s| id|
+-----+---+
|test1|  1|
|test2|  2|
+-----+---+

scala> df.transpose().show()
+---+-----+-----+
|key|test1|test2|
+---+-----+-----+
| id|    1|    2|
+---+-----+-----+
```

Repeated values in  first column:
```scala
scala> val df = Seq(("test", 1), ("test", 2)).toDF("s", "id")
val df: org.apache.spark.sql.DataFrame = [s: string, id: int]

scala> df.show()
+----+---+
|   s| id|
+----+---+
|test|  1|
|test|  2|
+----+---+

scala> df.transpose().show()
+---+----+
|key|test|
+---+----+
| id|   1|
+---+----+
```
